### PR TITLE
Clarify configuration by using better names.

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ spec:
     email: <YOUR ACME E-MAIL ADDRESS>
     server: https://acme-v02.api.letsencrypt.org/directory
     privateKeySecretRef:
-      name: cert-manager-desec-http-secret
+      name: acme-account
     solvers:
     - dns01:
         webhook:
@@ -38,7 +38,7 @@ spec:
           config:
             apiUrl: https://desec.io/api/v1
             domainName: <YOUR DNS ZONE>
-            secretName: cert-domain-tls-key-<YOUR DNS ZONE>
+            secretName: desec-access-token
             secretKeyName: desec-token
 ```
 
@@ -48,7 +48,7 @@ apiVersion: v1
 kind: Secret
 type: Opaque
 metadata:
-  name: cert-domain-tls-key-<DNS ZONE>
+  name: desec-access-token
   namespace: cert-manager
 stringData:
   desec-token: <YOUR DESEC TOKEN>
@@ -77,7 +77,7 @@ service:
   port: 443
 
 secretName:
-- cert-domain-tls-key-<YOUR DNS ZONE>
+- desec-access-token
 
 resources:
   limits:

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -26,8 +26,10 @@ service:
   type: ClusterIP
   port: 443
 
+# Used to generate a role binding that allows the webhook app
+# to read the secret with the token for accessing deSEC
 secretName:
-- cert-manager-desec-http-secret
+- desec-access-token
 
 resources:
   limits:


### PR DESCRIPTION
Great work! However, configuring it took some time due to some badly chosen names.

 * `spec.acme.privateKeySecretRef` has nothing to do with the deSEC webhook app. It's sample value in the
    ["grandfather" project]() was "letsencrypt-staging" (because this is what they used). My proposal is a bit
    more general. My point is that it should be clear that this refers your acme provider account, no matter
    what DNS backend you use.

 * Naming the secret with the deSEC access token `cert-domain-tls-key-<DNS ZONE>` suggests that it is
    domain specific. But it isn't. You can modify all of your zones at deSEC with a single token. (Well, you can
    restrict IP ranges, but I assume that a user who makes use of this feature knows how to adapt the
    webhook app configuration.)

 * The current usage of the sanple's value `spec.acme.privateKeySecretRef.name` in the default `values.yaml` is extremely
    irritating, because no role binding has to be generated for *that* secret.